### PR TITLE
adding exact-timestamps option for small changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 RUN pip install -U pip awscli && \
     apk add --no-cache --update rsync

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ s3get () {
     echo "sync from s3"
     mkdir -p ${DEST_PATH}
 
-    result=$(aws s3 sync s3://${AWS_BUCKET}/${KEY_PATH} ${DEST_PATH} --exclude "*.pyc" --delete 2>&1)
+    result=$(aws s3 sync --exact-timestamps s3://${AWS_BUCKET}/${KEY_PATH} ${DEST_PATH} --exclude "*.pyc" --delete 2>&1)
     result_code=$?
 
     if [[ $result_code != 0 ]]; then


### PR DESCRIPTION
According to AWS document [1] for s3 sync, the "aws s3 sync" command requires "--exact-timestamps" option. 
Because small changes are not affected to new version of source code if the source code file size is same. 
For example, the sync command keeps an old version even though you fix your typo in your source code. 

"--exact-timestamps (boolean) When syncing from S3 to local, same-sized items will be ignored only when the timestamps match exactly. The default behavior is to ignore same-sized items unless the local version is newer than the S3 version." [1] 

[1] https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html